### PR TITLE
Pom enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ target
 .project
 .classpath
 .vscode
+.factorypath
 
 # OS generated files #
 ######################

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ are coupled to Keycloak versions. After (major) Keycloak upgrades, you will almo
 certainly have also to update this provider.  
 
 ## Compatibility
-* Keycloak 26.5.x: Release `26.5.7`
+* Keycloak 26.6.x: Release `26.6.1`
+* Keycloak 26.5.x: Release `26.5.3`
 * Keycloak 26.4.x: Release `26.4.2`
 * Keycloak 26.3.x: Release `26.3.1`
 * Keycloak 26.2.x: Release `26.2.3`
@@ -39,7 +40,12 @@ certainly have also to update this provider.
 * Keycloak 19.x.x: Release `1.0.6`
 
 ## Configuration
-### Release 26.5.0 (latest, Keycloak 26.5.x compatibility)
+### Release 26.6.1 (latest, Keycloak 26.6.x compatibility)
+Detailed instructions on how to install and configure this component are 
+available in the project wiki (https://github.com/italia/spid-keycloak-provider/wiki/Installing-the-SPID-provider).
+To avoid errors, it's suggested to use anyway https://github.com/nicolabeghin/keycloak-cieid-provider-configuration-client
+
+### Release 26.5.0 (Keycloak 26.5.x compatibility)
 Detailed instructions on how to install and configure this component are 
 available in the project wiki (https://github.com/italia/spid-keycloak-provider/wiki/Installing-the-SPID-provider).
 To avoid errors, it's suggested to use anyway https://github.com/nicolabeghin/keycloak-cieid-provider-configuration-client

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ are coupled to Keycloak versions. After (major) Keycloak upgrades, you will almo
 certainly have also to update this provider.  
 
 ## Compatibility
-* Keycloak 26.5.x: Release `26.5.3`
+* Keycloak 26.5.x: Release `26.5.7`
 * Keycloak 26.4.x: Release `26.4.2`
 * Keycloak 26.3.x: Release `26.3.1`
 * Keycloak 26.2.x: Release `26.2.3`

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <version.keycloak>26.5.3</version.keycloak>
+
+        <xmlunit.version>2.11.0</xmlunit.version>
+
         <junit-jupiter.version>5.13.4</junit-jupiter.version>
         <mockito.version>5.18.0</mockito.version>
     </properties>
@@ -101,13 +104,13 @@
         <dependency>
             <groupId>org.xmlunit</groupId>
             <artifactId>xmlunit-core</artifactId>
-            <version>2.9.0</version>
+            <version>${xmlunit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.xmlunit</groupId>
             <artifactId>xmlunit-placeholders</artifactId>
-            <version>2.9.0</version>
+            <version>${xmlunit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -146,6 +149,40 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.5.5</version>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.14</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                        <phase>prepare-package</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <version>12.2.0</version>
+                <configuration>
+                    <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.lscorcia</groupId>
     <artifactId>keycloak-cieid-provider</artifactId>
-    <version>26.5.3-BIS</version>
+    <version>26.5.7</version>
     <packaging>jar</packaging>
 
     <name>Keycloak CIE ID Service Provider</name>
@@ -19,7 +19,7 @@
         <failOnMissingWebXml>false</failOnMissingWebXml>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <version.keycloak>26.5.3</version.keycloak>
+        <version.keycloak>26.5.7</version.keycloak>
 
         <xmlunit.version>2.11.0</xmlunit.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
             <version>${version.keycloak}</version>
             <scope>provided</scope>
         </dependency>
-        
+
         <!-- test dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -105,12 +105,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-                <groupId>org.glassfish.jersey.core</groupId>
-                <artifactId>jersey-common</artifactId>
-                <version>3.1.5</version>
-                <scope>test</scope>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-common</artifactId>
+            <version>3.1.5</version>
+            <scope>test</scope>
         </dependency>
-
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.lscorcia</groupId>
     <artifactId>keycloak-cieid-provider</artifactId>
-    <version>26.5.7</version>
+    <version>26.6.1</version>
     <packaging>jar</packaging>
 
     <name>Keycloak CIE ID Service Provider</name>
@@ -19,7 +19,7 @@
         <failOnMissingWebXml>false</failOnMissingWebXml>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <keycloak.version>26.5.7</keycloak.version>
+        <keycloak.version>26.6.1</keycloak.version>
 
         <xmlunit.version>2.11.0</xmlunit.version>
 
@@ -186,21 +186,6 @@
                             <goal>report</goal>
                         </goals>
                         <phase>prepare-package</phase>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.owasp</groupId>
-                <artifactId>dependency-check-maven</artifactId>
-                <version>12.2.1</version>
-                <configuration>
-                    <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@
             <plugin>
                 <groupId>org.owasp</groupId>
                 <artifactId>dependency-check-maven</artifactId>
-                <version>12.2.0</version>
+                <version>12.2.1</version>
                 <configuration>
                     <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
-                    <version>3.0.0-M1</version>
+                    <version>3.3.1</version>
                     <configuration>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
                         <tagNameFormat>@{project.version}</tagNameFormat>

--- a/pom.xml
+++ b/pom.xml
@@ -19,12 +19,17 @@
         <failOnMissingWebXml>false</failOnMissingWebXml>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <version.keycloak>26.5.7</version.keycloak>
+        <keycloak.version>26.5.7</keycloak.version>
 
         <xmlunit.version>2.11.0</xmlunit.version>
 
-        <junit-jupiter.version>5.13.4</junit-jupiter.version>
-        <mockito.version>5.18.0</mockito.version>
+        <!-- Surefire properties for keycloak-test-framework support -->
+        <testframework.surefire.args>
+            -XX:+ExitOnOutOfMemoryError
+            -XX:+HeapDumpOnOutOfMemoryError
+            -Djava.util.logging.manager=org.jboss.logmanager.LogManager
+            -Djava.util.concurrent.ForkJoinPool.common.threadFactory=io.quarkus.bootstrap.forkjoin.QuarkusForkJoinWorkerThreadFactory
+        </testframework.surefire.args>
     </properties>
 
     <scm>
@@ -32,73 +37,85 @@
         <tag>HEAD</tag>
     </scm>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.keycloak.testframework</groupId>
+                <artifactId>keycloak-test-framework-bom</artifactId>
+                <version>${keycloak.version}</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-core</artifactId>
-            <version>${version.keycloak}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-saml-core</artifactId>
-            <version>${version.keycloak}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-saml-adapter-api-public</artifactId>
-            <version>${version.keycloak}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-server-spi</artifactId>
-            <version>${version.keycloak}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-server-spi-private</artifactId>
-            <version>${version.keycloak}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-services</artifactId>
-            <version>${version.keycloak}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-crypto-default</artifactId>
-            <version>${version.keycloak}</version>
             <scope>provided</scope>
         </dependency>
 
         <!-- test dependencies -->
         <dependency>
+            <groupId>org.keycloak.testframework</groupId>
+            <artifactId>keycloak-test-framework-core</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.keycloak</groupId>
+                    <artifactId>keycloak-crypto-fips1402</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>org.jboss.slf4j</groupId>
             <artifactId>slf4j-jboss-logmanager</artifactId>
-            <version>2.0.2.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.17</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>${junit-jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -149,6 +166,9 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.5.5</version>
+                <configuration>
+                    <argLine>${testframework.surefire.args}</argLine>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,9 +20,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <version.keycloak>26.5.3</version.keycloak>
-        <slf4j-api.version>1.7.30</slf4j-api.version>
-        <junit-jupiter.version>5.8.2</junit-jupiter.version>
-        <mockito.version>4.3.1</mockito.version>
+        <junit-jupiter.version>5.13.4</junit-jupiter.version>
+        <mockito.version>5.18.0</mockito.version>
     </properties>
 
     <scm>
@@ -68,11 +67,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>${slf4j-api.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.keycloak</groupId>
             <artifactId>keycloak-crypto-default</artifactId>
             <version>${version.keycloak}</version>
@@ -80,6 +74,18 @@
         </dependency>
 
         <!-- test dependencies -->
+        <dependency>
+            <groupId>org.jboss.slf4j</groupId>
+            <artifactId>slf4j-jboss-logmanager</artifactId>
+            <version>2.0.2.Final</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.17</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
@@ -139,20 +145,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <!-- latest version (2.20.1) does not work well with JUnit5 -->
-                <version>2.19.1</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.junit.platform</groupId>
-                        <artifactId>junit-platform-surefire-provider</artifactId>
-                        <version>1.0.3</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.junit.jupiter</groupId>
-                        <artifactId>junit-jupiter-engine</artifactId>
-                        <version>${junit-jupiter.version}</version>
-                    </dependency>
-                </dependencies>
+                <version>3.5.5</version>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,6 @@
         <slf4j-api.version>1.7.30</slf4j-api.version>
         <junit-jupiter.version>5.8.2</junit-jupiter.version>
         <mockito.version>4.3.1</mockito.version>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
     </properties>
 
     <scm>
@@ -135,9 +133,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
+                <version>3.15.0</version>
                 <configuration>
-                    <release>11</release>
+                    <release>17</release>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/test/resources/keycloak-test.properties
+++ b/src/test/resources/keycloak-test.properties
@@ -1,0 +1,1 @@
+com.redhat.fips=false


### PR DESCRIPTION
Con questa PR vorrei ribaltare su questo progetto gli stessi aggiornamenti che ho già pubblicato, più altri che sono in lavorazione, sul progetto del connettore spid per keycloak.
In particolare, oltre ai tag di release, all'aggiornamento delle versioni alla ultima 26.5.7 del ramo 26 del keycloak, ho importato il keycloak-test-framework-bom per eseguire dei test del progetto su un keycloak ridotto, che tra l'altro consente di ovviare la specifica di varie librerie agendo tramite dependency management.
Al momento non ho toccato altre parti di codice, appena riesco vorrei provare ad implementare dei test basati sulla soluzione appena introdotta per verificare il funzionamento del provider anche in una fase più orientata all'integrazione.
Fammi sapere se le modifiche possono andare bene oppure se serve fare qualche correzione.
Grazie, saluti