### PR TITLE
Build optimization through Dockerfile improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM maven:3-eclipse-temurin-21-alpine
+WORKDIR /opt/app
+
+# to cache dependencies
+ADD pom*.xml .
+RUN mvn verify --fail-never
+
+# build final JAR
+COPY . .
+RUN mvn package

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SERVICE_TARGET := maven:3-eclipse-temurin-21-alpine
+SERVICE_TARGET := cieid-keycloak-provider
 
 # all our targets are phony (no files to check).
 .PHONY: help package
@@ -11,5 +11,14 @@ help:
 
 build: package
 
+extract:
+	$(eval DOCKER_CONTAINER := $(shell docker create --name tc ${SERVICE_TARGET}:latest))
+	mkdir -p target
+	docker cp ${DOCKER_CONTAINER}:/opt/app/target/cieid-provider.jar target/
+	docker rm tc
+
 package:
-	docker run --rm -v ${shell pwd}:/opt/app -w /opt/app ${SERVICE_TARGET} bash -c "mvn clean package"
+	rm -fr target || true
+	-docker rm tc
+	docker build -t ${SERVICE_TARGET} .
+	$(MAKE) extract


### PR DESCRIPTION
By aligning the Makefile and Dockerfile with those used in the spid-keycloak-provider project, I attempted to optimize the build process. Previously, the build did not take advantage of Docker image layer caching and downloaded all Maven dependencies from scratch on every execution.